### PR TITLE
Fix JWT token verification

### DIFF
--- a/src/main/java/com/trust/now/service/auth/JwtServiceImpl.java
+++ b/src/main/java/com/trust/now/service/auth/JwtServiceImpl.java
@@ -62,9 +62,10 @@ public class JwtServiceImpl implements AuthTokenService {
         }
     }
 
+    @Override
     public UserAuthentication parseToken(String token) {
         Jws<Claims> claimsJws = Jwts.parser()
-                .decryptWith(secretKey)
+                .verifyWith(secretKey)
                 .requireIssuer(issuer)
                 .build()
                 .parseSignedClaims(token);


### PR DESCRIPTION
## Summary
- use `verifyWith` instead of `decryptWith` in `JwtServiceImpl`
- add `@Override` annotation on the `parseToken` method

## Testing
- `./mvnw -q test` *(fails: network access required to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686ffbf88e48832684faa0465d708310